### PR TITLE
Update .po file generation to be sorted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.2
+
+* Ensure that PO file merging is performed by file, avoiding changes in PO file order (which cases large PO file deltas)
+
 ## 0.5.1
 
 * Include fuzzy translations in the compiled `.mo` files

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -181,6 +181,7 @@ class POFile:
             "contents.pot",
             "-U",
             "-N",
+            "--sort-by-file",
             "--backup=simple",
         ]
         reporter.report_debug_info("msgmerge cmd line", cmdline)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
There is a flag in `msgmerge` that allows you to sort by file location (`--sort-by-file`). I have updated the `msgmerge` CLI invocation to include this flag.
<!--- What problem does this change solve? -->
Without this flag, every time a string is updated, the affected page's string set is shifted to the beginning of the .po file, which ostensibly rewrites the entire file every time. With this flag applied, the .po files are in a particular order already, and the updated string is added in place. 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
This issue was discovered in https://github.com/beeware/beeware.github.io/pull/646. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
