### PR TITLE
Sort POT content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.4
+
+* POT content is now sorted by path.
+
 ## 0.5.3
 
 * `POT-Creation-Date` in `.pot` file is only updated on initial creation.

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -101,18 +101,19 @@ class Translations:
 
         pot_elements = [header]
 
-        for msg, paths in self.translations.items():
-            if msg:  # Generate msgid/msgstr pair only if content exists
-                for token, repl in {
-                    "\\": "\\\\",
-                    "\n": "\\n",
-                    "\t": "\\t",
-                    '"': '\\"',
-                }.items():
-                    msg = msg.replace(token, repl)
-                pot_elements.append(
-                    f'#: {" ".join(paths)}\nmsgid "{msg}"\nmsgstr ""\n\n'
-                )
+        # Sort the translations by path, only include a key if content exists.
+        translations_by_path = [
+            (sorted(paths), msg) for msg, paths in self.translations.items() if msg
+        ]
+        for paths, msg in sorted(translations_by_path):
+            for token, repl in {
+                "\\": "\\\\",
+                "\n": "\\n",
+                "\t": "\\t",
+                '"': '\\"',
+            }.items():
+                msg = msg.replace(token, repl)
+            pot_elements.append(f'#: {" ".join(paths)}\nmsgid "{msg}"\nmsgstr ""\n\n')
         return "".join(pot_elements)
 
     @staticmethod


### PR DESCRIPTION
To ensure an idempotent order of POT file creation, sort the POT entries by the paths for each msg string. Since each message could occur on multiple paths, sort the paths as well, and use that list as the sort order.