### PR TITLE
v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Ensure that POT content is now sorted by path when merging POTs from multiple sources (i.e., templates and content).
 * `xgettext` is used to merge POT files instead of `msgcat`, providing a better header and merging of same strings from different sources.
 * The initially generated PO files will now have a header compatible with GNOME's Translation Editor, since they will have a non-placeholder `Project-Id-Version`. Existing users hitting this problem will need to fill in the `Project-Id-Version` header manually.
+* Translations in templates now provide pgettext and ngettext methods.
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Ensure that POT content is now sorted by path when merging POTs from multiple sources (i.e., templates and content).
 * `xgettext` is used to merge POT files instead of `msgcat`, providing a better header and merging of same strings from different sources.
+* The generated PO files will now have a header compatible with GNOME's Translation Editor.
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * `xgettext` is used to merge POT files instead of `msgcat`, providing a better header and merging of same strings from different sources.
 * The initially generated PO files will now have a header compatible with GNOME's Translation Editor, since they will have a non-placeholder `Project-Id-Version`. Existing users hitting this problem will need to fill in the `Project-Id-Version` header manually.
 * Translations in templates now provide pgettext and ngettext methods.
-* The bug with non-English content is resolved.
+* The bug where deletion of strings from the English PO file with non-English content is resolved.
+* When updating translated PO files, the content-language PO file strings are automatically filled with the message IDs.
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.5.5
 
 * Ensure that POT content is now sorted by path when merging POTs from multiple sources (i.e., templates and content).
-* POT contents now cumulate (i.e., instead of `--use-first`) when merging POTs using `msgcat`, such that source information is preserved from all POT files.
+* `xgettext` is used to merge POT files instead of `msgcat`, providing a better header and merging of same strings from different sources.
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 * Ensure that POT content is now sorted by path when merging POTs from multiple sources (i.e., templates and content).
 * `xgettext` is used to merge POT files instead of `msgcat`, providing a better header and merging of same strings from different sources.
 * The initially generated PO files will now have a header compatible with GNOME's Translation Editor, since they will have a non-placeholder `Project-Id-Version`. Existing users hitting this problem will need to fill in the `Project-Id-Version` header manually.
-* Translations in templates now provide pgettext and ngettext methods.
+* Translations in templates now provide `pgettext` and `npgettext` methods.
 * The bug where deletion of strings from the English PO file with non-English content is resolved.
 * When updating translated PO files, the content-language PO file strings are automatically filled with the message IDs. Side effects with plurals are documented.
+* A bug with discriminating between Markdown headings and Lektor block seperations has been fixed; the older heuristic with checking for colons in the previous line is replaced with simply checking for 3 dashes after stripped.
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Ensure that POT content is now sorted by path when merging POTs from multiple sources (i.e., templates and content).
 * `xgettext` is used to merge POT files instead of `msgcat`, providing a better header and merging of same strings from different sources.
-* The generated PO files will now have a header compatible with GNOME's Translation Editor.
+* The initially generated PO files will now have a header compatible with GNOME's Translation Editor, since they will have a non-placeholder `Project-Id-Version`. Existing users hitting this problem will need to fill in the `Project-Id-Version` header manually.
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * The initially generated PO files will now have a header compatible with GNOME's Translation Editor, since they will have a non-placeholder `Project-Id-Version`. Existing users hitting this problem will need to fill in the `Project-Id-Version` header manually.
 * Translations in templates now provide pgettext and ngettext methods.
 * The bug where deletion of strings from the English PO file with non-English content is resolved.
-* When updating translated PO files, the content-language PO file strings are automatically filled with the message IDs.
+* When updating translated PO files, the content-language PO file strings are automatically filled with the message IDs. Side effects with plurals are documented.
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.5
+
+* Ensure that POT content is now sorted by path when merging POTs from multiple sources (i.e., templates and content).
+* POT contents now cumulate (i.e., instead of `--use-first`) when merging POTs using `msgcat`, such that source information is preserved from all POT files.
+
 ## 0.5.4
 
 * POT content is now sorted by path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `xgettext` is used to merge POT files instead of `msgcat`, providing a better header and merging of same strings from different sources.
 * The initially generated PO files will now have a header compatible with GNOME's Translation Editor, since they will have a non-placeholder `Project-Id-Version`. Existing users hitting this problem will need to fill in the `Project-Id-Version` header manually.
 * Translations in templates now provide pgettext and ngettext methods.
+* The bug with non-English content is resolved.
 
 ## 0.5.4
 

--- a/README.md
+++ b/README.md
@@ -96,12 +96,6 @@ For example:
 
 As with the previous example, `body` and `title` field content will be translated. However, in this example, `image` and `image_position` will not.
 
-### Non-english content
-
-Due to a limitation of `msginit`, it is difficult to translate a site when the primary language is set to anything but English.
-
-If your default content language is not English, you will have to edit the first `contents-en.po` file and remove the translations.
-
 ### Plural Forms
 
 If you're using `{% pluralize %}` in your Jinja templates, make sure you fill in the plural forms in the PO headers manually, then make sure you have the correct number of `msgstr[x]`s.

--- a/README.md
+++ b/README.md
@@ -169,9 +169,7 @@ You must run `lektor build` once to generate the list of `contents-xx.po` files.
 
 If you're using `{% pluralize %}` or `ngettext` or the like in your Jinja templates, make sure you fill in the plural forms in the PO headers manually, then make sure you have the correct
 number of `msgstr[x]`s.  The plugin automatically fills `msgstr`s into the PO file of your source lanaguage (which msginit only does for English), but since it doesn't parse plural forms,
-care must be taken to ensure that there are proper plural form `msgstr`s in your source language PO file; in particular, for languages that does not simply use `msgstr[0]` as singular and
-`msgstr[1]` as plural, you must manually alter your PO file to have the correct plurals.  Therefore, all such filled-in source-language plural PO entries that aren't in English are marked
-fuzzy, and the plural forms would need to be adjusted manually.
+any non-English PO file will not have its plural message strings filled in.  Those must be done manually in the source-language PO file if simply singular and plural strings does not suffice .
 
 ### Project file
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ As with the previous example, `body` and `title` field content will be translate
 
 If you're using `{% pluralize %}` in your Jinja templates, make sure you fill in the plural forms in the PO headers manually, then make sure you have the correct number of `msgstr[x]`s.
 In addition, in languages where `msgstr[0]` is not singular, the `msgstr[x]` entries that gets filled in will be incorrect because `msgstr[0]` get filled in with singular and the rest with
-plural -- for that reason, all filling of source language po files will have such plural entries marked fuzzy; manual editing to clear the fuzzy flag and/or correct the plural forms is desried.
+plural -- for that reason, all filling of source language po files except when such source language is English will have such plural entries marked fuzzy; manual editing to clear the fuzzy
+flag and/or correct the plural forms is desried.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ A `babel.cfg` must be created in your project root with the following content:
     [jinja2: **/templates/**.html]
     encoding = utf-8
 
+#### Whitespace Trimming during Extraction
+
+If you're using `{% trans %}` blocks in your template files, the `trimmed` policy is enabled for Jinja's i18n plugin, so all whitespaces would be trimmed at the beginning and end of those
+blocks.  However, in order for PyBabel's extraction to also work properly this way, one shall add `trimmed = True` to the jinja2 section of the `babel.cfg` configuration file.
+
 ### Translatable fields
 
 In order for a field to be marked as translatable, an option has to be set in the field definition. Both blocks and flowblocks fields are translatable.
@@ -95,13 +100,6 @@ For example:
     default = right
 
 As with the previous example, `body` and `title` field content will be translated. However, in this example, `image` and `image_position` will not.
-
-### Plural Forms
-
-If you're using `{% pluralize %}` in your Jinja templates, make sure you fill in the plural forms in the PO headers manually, then make sure you have the correct number of `msgstr[x]`s.
-In addition, in languages where `msgstr[0]` is not singular, the `msgstr[x]` entries that gets filled in will be incorrect because `msgstr[0]` get filled in with singular and the rest with
-plural -- for that reason, all filling of source language po files except when such source language is English will have such plural entries marked fuzzy; manual editing to clear the fuzzy
-flag and/or correct the plural forms is desried.
 
 ## Installation
 
@@ -166,6 +164,14 @@ For each translation language listed in the configuration file, a `content-xx.po
 All translation files (`contents-*.po`) are then compiled and merged with the original `contents.lr` files to produce all the `contents-xx.lr` files in their respective directories.
 
 You must run `lektor build` once to generate the list of `contents-xx.po` files. After that, once a translation change is applied to a `contents-xx.po` file, the site must be built again for the changes to be applied to the associated `contents-xx.lr` file. This results in the changes being rendered on the site.
+
+### Plural Forms
+
+If you're using `{% pluralize %}` or `ngettext` or the like in your Jinja templates, make sure you fill in the plural forms in the PO headers manually, then make sure you have the correct
+number of `msgstr[x]`s.  The plugin automatically fills `msgstr`s into the PO file of your source lanaguage (which msginit only does for English), but since it doesn't parse plural forms,
+care must be taken to ensure that there are proper plural form `msgstr`s in your source language PO file; in particular, for languages that does not simply use `msgstr[0]` as singular and
+`msgstr[1]` as plural, you must manually alter your PO file to have the correct plurals.  Therefore, all such filled-in source-language plural PO entries that aren't in English are marked
+fuzzy, and the plural forms would need to be adjusted manually.
 
 ### Project file
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ As with the previous example, `body` and `title` field content will be translate
 ### Plural Forms
 
 If you're using `{% pluralize %}` in your Jinja templates, make sure you fill in the plural forms in the PO headers manually, then make sure you have the correct number of `msgstr[x]`s.
-In addition, in languages where `msgstr[0]` is not singular and the rest all uses the plural string, the `msgstr[x]` entries that gets filled in will be incorrect -- for that reason, all
-filling of source language po files will have such plural entries marked fuzzy; manual editing to clear the fuzzy flag and/or correct the plural forms is desried.
+In addition, in languages where `msgstr[0]` is not singular, the `msgstr[x]` entries that gets filled in will be incorrect because `msgstr[0]` get filled in with singular and the rest with
+plural -- for that reason, all filling of source language po files will have such plural entries marked fuzzy; manual editing to clear the fuzzy flag and/or correct the plural forms is desried.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ As with the previous example, `body` and `title` field content will be translate
 ### Plural Forms
 
 If you're using `{% pluralize %}` in your Jinja templates, make sure you fill in the plural forms in the PO headers manually, then make sure you have the correct number of `msgstr[x]`s.
+In addition, in languages where `msgstr[0]` is not singular and the rest all uses the plural string, the `msgstr[x]` entries that gets filled in will be incorrect -- for that reason, all
+filling of source language po files will have such plural entries marked fuzzy; manual editing to clear the fuzzy flag and/or correct the plural forms is desried.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ A `babel.cfg` must be created in your project root with the following content:
     [jinja2: **/templates/**.html]
     encoding = utf-8
 
+If you plan to extract from your templates, and the templates use functionality provided in Jinja2 extensions, specify
+something like the following on an additional line in the config file.  For example, if you use ``do`` statements, the
+configuration file shall be:
+```
+[jinja2: **/templates/**.html]
+encoding = utf-8
+extensions = jinja2.ext.do
+```
+
 #### Whitespace Trimming during Extraction
 
 If you're using `{% trans %}` blocks in your template files, the `trimmed` policy is enabled for Jinja's i18n plugin, so all whitespaces would be trimmed at the beginning and end of those

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Due to a limitation of `msginit`, it is difficult to translate a site when the p
 
 If your default content language is not English, you will have to edit the first `contents-en.po` file and remove the translations.
 
+### Plural Forms
+
+If you're using `{% pluralize %}` in your Jinja templates, make sure you fill in the plural forms in the PO headers manually, then make sure you have the correct number of `msgstr[x]`s.
+
 ## Installation
 
 ### Prerequisites

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -140,7 +140,7 @@ class Translations:
         msgcat = locate_executable("msgcat")
         if msgcat is None:
             msgcat = "/usr/bin/msgcat"
-        cmdline = [msgcat, "--use-first"]
+        cmdline = [msgcat, "--use-first", "-F"]
         cmdline.extend(from_filenames)
         cmdline.extend(("-o", to_filename))
         reporter.report_debug_info("msgcat cmd line", cmdline)
@@ -183,6 +183,7 @@ class POFile:
             "-o",
             self.FILENAME_PATTERN.format(self.language),
             "--no-translator",
+            "-F",
         ]
         reporter.report_debug_info("msginit cmd line", cmdline)
         portable_popen(cmdline, cwd=self.i18npath).wait()

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -297,20 +297,6 @@ class POFile:
             self._msg_fmt(locale_dirname)
 
 
-def line_starts_new_block(line, prev_line):
-    """
-    Detect a new block in a Lektor document. Blocks are delimited by a line
-    containing 3 or more dashes. This actually matches the definition of a
-    markdown level 2 heading, so this function returns False if no colon was
-    found in the line before, e.g. it isn't a new block with a key: value pair
-    before.
-    """
-    if not prev_line or ":" not in prev_line:
-        return False  # could be a Markdown heading
-    line = line.strip()
-    return line == "-" * len(line) and len(line) >= 3
-
-
 def split_paragraphs(document):
     if isinstance(document, (list, tuple)):
         document = "".join(document)  # list of lines
@@ -453,16 +439,13 @@ class I18NPlugin(Plugin):
         blocks = []
         count_lines_block = 0  # counting the number of lines of the current block
         is_content = False
-        prev_line = None
         for line in lines:
             stripped_line = line.strip()
             if not stripped_line:  # empty line
                 blocks.append(("raw", "\n"))
                 continue
             # line like "---*" or a new block tag
-            if line_starts_new_block(stripped_line, prev_line) or block2re.search(
-                stripped_line
-            ):
+            if stripped_line == "---" or block2re.search(stripped_line):
                 count_lines_block = 0
                 is_content = False
                 blocks.append(("raw", line))
@@ -482,7 +465,6 @@ class I18NPlugin(Plugin):
                     is_content = True
             if is_content:
                 blocks.append(("translatable", line))
-            prev_line = line
         # join neighbour blocks of same type
         newblocks = []
         for type, data in blocks:

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -239,6 +239,7 @@ class POFile:
         reporter.report_debug_info("msginit cmd line", cmdline)
         portable_popen(cmdline, cwd=self.i18npath).wait()
         clear_translations(os.path.join(self.i18npath, self.FILENAME_PATTERN.format(self.language)))
+        self.reformat()
 
     def _msg_merge(self):
         """Merges an existing <language>.po file with .pot file"""
@@ -627,4 +628,4 @@ class I18NPlugin(Plugin):
             po_file.generate()
             if language == self.content_language:
                 fill_translations(os.path.join(po_file.i18npath, po_file.FILENAME_PATTERN.format(po_file.language)))
-            po_file.reformat()
+                po_file.reformat()

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -88,24 +88,25 @@ class Translations:
 
     def as_pot(self, content_language, header):
         """returns a POT version of the translation dictionary"""
-        now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
-        now += f"+{(time.tzname[0])}"
-        header = dedent(
-            f"""msgid ""
-            msgstr ""
-            "Project-Id-Version: PACKAGE VERSION\\n"
-            "Report-Msgid-Bugs-To: \\n"
-            "POT-Creation-Date: {now}\\n"
-            "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
-            "Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
-            "Language-Team: {content_language} <LL@li.org>\\n"
-            "Language: {content_language}\\n"
-            "MIME-Version: 1.0\\n"
-            "Content-Type: text/plain; charset=UTF-8\\n"
-            "Content-Transfer-Encoding: 8bit\\n"
+        if header is None:
+            now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+            now += f"+{(time.tzname[0])}"
+            header = dedent(
+                f"""msgid ""
+                msgstr ""
+                "Project-Id-Version: PACKAGE VERSION\\n"
+                "Report-Msgid-Bugs-To: \\n"
+                "POT-Creation-Date: {now}\\n"
+                "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
+                "Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+                "Language-Team: {content_language} <LL@li.org>\\n"
+                "Language: {content_language}\\n"
+                "MIME-Version: 1.0\\n"
+                "Content-Type: text/plain; charset=UTF-8\\n"
+                "Content-Transfer-Encoding: 8bit\\n"
 
-            """
-        )
+                """
+            )
 
         pot_elements = [header]
 

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -136,7 +136,7 @@ class Translations:
             f.write(self.as_pot(language, header))
 
     @staticmethod
-    def merge_pot(from_filenames, to_filename):
+    def merge_pot(from_filenames, to_filename, projectname):
         # Get the POT Creation Date of the first file and inject it later.
         pattern = r'("POT-Creation-Date:\s*)(\d{4}-\d{2}-\d{2}.*)(\\n")'
         with open(from_filenames[0], 'r', encoding='utf-8') as f:
@@ -572,7 +572,7 @@ class I18NPlugin(Plugin):
         reporter.report_generic(f"{relpath(pots[0], builder.env.root_path)} generated")
         pots = [p for p in pots if os.path.exists(p)]  # only keep existing ones
         if len(pots) > 1:
-            translations.merge_pot(pots, contents_pot_filename)
+            translations.merge_pot(pots, contents_pot_filename, self.env.project.name)
             reporter.report_generic(
                 f"Merged POT files "
                 f"{', '.join(relpath(p, builder.env.root_path) for p in pots)}"

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -215,8 +215,7 @@ def fill_translations(po_filepath, save_path=None):
 
         if need_plural_fill and '+en.po' in basename(po_filepath):
             for idx in entry.msgstr_plural:
-                if not entry.msgstr_plural[idx]:
-                    entry.msgstr_plural[idx] = entry.msgid if int(idx) == 0 else entry.msgid_plural
+                entry.msgstr_plural[idx] = entry.msgid if int(idx) == 0 else entry.msgid_plural
 
         if 'fuzzy' in entry.flags:
             entry.flags.remove('fuzzy')

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -195,10 +195,15 @@ def fill_translations(po_filepath, save_path=None):
     po = polib.pofile(po_filepath)
     
     for entry in po:
-        if not entry.msgstr:
+        # If we fuzzy-matched, we'd need to properly re-fill
+        # the entries.  Particularly important is that when
+        # you add the plural form of a string... msgmerge seem
+        # to fill the plural field with the singular one, and
+        # mark it fuzzy...
+        if not entry.msgstr or entry.fuzzy:
             entry.msgstr = entry.msgid
 
-        need_plural_fill = False
+        need_plural_fill = entry.fuzzy
         if entry.msgstr_plural:
             for idx in entry.msgstr_plural:
                 if not entry.msgstr_plural[idx]:

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -193,14 +193,21 @@ def clear_translations(po_filepath, save_path=None):
 
 def fill_translations(po_filepath, save_path=None):
     po = polib.pofile(po_filepath)
+    
     for entry in po:
-        entry.msgstr = entry.msgid
+        if not entry.msgstr:
+            entry.msgstr = entry.msgid
+
+        plural_updated = False
         if entry.msgstr_plural:
             for idx in entry.msgstr_plural:
-                if int(idx) == 0:
-                    entry.msgstr_plural[idx] = entry.msgid
-                else:
-                    entry.msgstr_plural[idx] = entry.msgid_plural
+                if not entry.msgstr_plural[idx]:
+                    entry.msgstr_plural[idx] = entry.msgid if int(idx) == 0 else entry.msgid_plural
+                    plural_updated = True
+
+        if plural_updated and 'fuzzy' not in entry.flags:
+            entry.flags.append('fuzzy')
+
     po.save(save_path or po_filepath)
 
 

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -230,7 +230,7 @@ class POFile:
         ]
         reporter.report_debug_info("msginit cmd line", cmdline)
         portable_popen(cmdline, cwd=self.i18npath).wait()
-        clear_translations(self.FILENAME_PATTERN.format(self.language))
+        clear_translations(os.path.join(self.i18npath, self.FILENAME_PATTERN.format(self.language)))
 
     def _msg_merge(self):
         """Merges an existing <language>.po file with .pot file"""
@@ -618,5 +618,5 @@ class I18NPlugin(Plugin):
             po_file = POFile(language, self.i18npath)
             po_file.generate()
             if language == self.content_language:
-                fill_translations(po_file.FILENAME_PATTERN.format(po_file.language))
+                fill_translations(os.path.join(po_file.i18npath, po_file.FILENAME_PATTERN.format(po_file.language)))
             po_file.reformat()

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -137,13 +137,13 @@ class Translations:
 
     @staticmethod
     def merge_pot(from_filenames, to_filename):
-        msgcat = locate_executable("msgcat")
-        if msgcat is None:
-            msgcat = "/usr/bin/msgcat"
-        cmdline = [msgcat, "-F"]
+        xgettext = locate_executable("xgettext")
+        if xgettext is None:
+            xgettext = "/usr/bin/xgettext"
+        cmdline = [xgettext, "--sort-by-file"]
         cmdline.extend(from_filenames)
         cmdline.extend(("-o", to_filename))
-        reporter.report_debug_info("msgcat cmd line", cmdline)
+        reporter.report_debug_info("xgettext cmd line", cmdline)
         portable_popen(cmdline).wait()
 
     @staticmethod

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -146,7 +146,7 @@ class Translations:
         xgettext = locate_executable("xgettext")
         if xgettext is None:
             xgettext = "/usr/bin/xgettext"
-        cmdline = [xgettext, "--sort-by-file", "--package-name=" + self.env.project.name, "--package-version=1.0"]
+        cmdline = [xgettext, "--sort-by-file", "--package-name=" + projectname, "--package-version=1.0"]
         cmdline.extend(from_filenames)
         cmdline.extend(("-o", to_filename))
         reporter.report_debug_info("xgettext cmd line", cmdline)

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -198,16 +198,16 @@ def fill_translations(po_filepath, save_path=None):
         if not entry.msgstr:
             entry.msgstr = entry.msgid
 
-        plural_updated = False
+        need_plural_fill = False
         if entry.msgstr_plural:
             for idx in entry.msgstr_plural:
                 if not entry.msgstr_plural[idx]:
-                    entry.msgstr_plural[idx] = entry.msgid if int(idx) == 0 else entry.msgid_plural
-                    plural_updated = True
+                    need_plural_fill = True
 
-        if plural_updated and 'fuzzy' not in entry.flags and 'en' not in basename(po_filepath):
-            entry.flags.append('fuzzy')
-
+        if need_plural_fill and '+en.po' in basename(po_filepath):
+            for idx in entry.msgstr_plural:
+                if not entry.msgstr_plural[idx]:
+                    need_plural_fill = True
     po.save(save_path or po_filepath)
 
 

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -9,6 +9,7 @@ from os.path import exists, join, relpath
 from pprint import PrettyPrinter
 from textwrap import dedent
 from urllib.parse import urljoin
+import polib
 
 from lektor.context import get_ctx
 from lektor.db import Page
@@ -87,25 +88,24 @@ class Translations:
 
     def as_pot(self, content_language, header):
         """returns a POT version of the translation dictionary"""
-        if header is None:
-            now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
-            now += f"+{(time.tzname[0])}"
-            header = dedent(
-                f"""msgid ""
-                msgstr ""
-                "Project-Id-Version: PACKAGE VERSION\\n"
-                "Report-Msgid-Bugs-To: \\n"
-                "POT-Creation-Date: {now}\\n"
-                "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
-                "Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
-                "Language-Team: {content_language} <LL@li.org>\\n"
-                "Language: {content_language}\\n"
-                "MIME-Version: 1.0\\n"
-                "Content-Type: text/plain; charset=UTF-8\\n"
-                "Content-Transfer-Encoding: 8bit\\n"
+        now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+        now += f"+{(time.tzname[0])}"
+        header = dedent(
+            f"""msgid ""
+            msgstr ""
+            "Project-Id-Version: PACKAGE VERSION\\n"
+            "Report-Msgid-Bugs-To: \\n"
+            "POT-Creation-Date: {now}\\n"
+            "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
+            "Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+            "Language-Team: {content_language} <LL@li.org>\\n"
+            "Language: {content_language}\\n"
+            "MIME-Version: 1.0\\n"
+            "Content-Type: text/plain; charset=UTF-8\\n"
+            "Content-Transfer-Encoding: 8bit\\n"
 
-                """
-            )
+            """
+        )
 
         pot_elements = [header]
 
@@ -181,6 +181,28 @@ class Translations:
 translations = Translations()  # let's have a singleton
 
 
+def clear_translations(po_filepath, save_path=None):
+    po = polib.pofile(po_filepath)
+    for entry in po:
+        entry.msgstr = ''
+        if entry.msgstr_plural:
+            for idx in entry.msgstr_plural:
+                entry.msgstr_plural[idx] = ''
+    po.save(save_path or po_filepath)
+
+def fill_translations(po_filepath, save_path=None):
+    po = polib.pofile(po_filepath)
+    for entry in po:
+        entry.msgstr = entry.msgid
+        if entry.msgstr_plural:
+            for idx in entry.msgstr_plural:
+                if int(idx) == 0:
+                    entry.msgstr_plural[idx] = entry.msgid
+                else:
+                    entry.msgstr_plural[idx] = entry.msgid_plural
+    po.save(save_path or po_filepath)
+
+
 class POFile:
     FILENAME_PATTERN = "contents+{}.po"
 
@@ -208,6 +230,7 @@ class POFile:
         ]
         reporter.report_debug_info("msginit cmd line", cmdline)
         portable_popen(cmdline, cwd=self.i18npath).wait()
+        clear_translations(self.FILENAME_PATTERN.format(self.language))
 
     def _msg_merge(self):
         """Merges an existing <language>.po file with .pot file"""
@@ -222,6 +245,11 @@ class POFile:
             "--backup=simple",
         ]
         reporter.report_debug_info("msgmerge cmd line", cmdline)
+        portable_popen(cmdline, cwd=self.i18npath).wait()
+    
+    def reformat(self):
+        msgcat = locate_executable("msgcat")
+        cmdline = [msgcat, self.FILENAME_PATTERN.format(self.language), "-o", self.FILENAME_PATTERN.format(self.language)]
         portable_popen(cmdline, cwd=self.i18npath).wait()
 
     def _prepare_locale_dir(self):
@@ -589,3 +617,6 @@ class I18NPlugin(Plugin):
         for language in self.translations_languages:
             po_file = POFile(language, self.i18npath)
             po_file.generate()
+            if language == self.content_language:
+                fill_translations(po_file.FILENAME_PATTERN.format(po_file.language))
+            po_file.reformat()

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -146,7 +146,7 @@ class Translations:
         xgettext = locate_executable("xgettext")
         if xgettext is None:
             xgettext = "/usr/bin/xgettext"
-        cmdline = [xgettext, "--sort-by-file"]
+        cmdline = [xgettext, "--sort-by-file", "--package-name=" + self.env.project.name, "--package-version=1.0"]
         cmdline.extend(from_filenames)
         cmdline.extend(("-o", to_filename))
         reporter.report_debug_info("xgettext cmd line", cmdline)

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -207,7 +207,7 @@ def fill_translations(po_filepath, save_path=None):
         if need_plural_fill and '+en.po' in basename(po_filepath):
             for idx in entry.msgstr_plural:
                 if not entry.msgstr_plural[idx]:
-                    need_plural_fill = True
+                    entry.msgstr_plural[idx] = entry.msgid if int(idx) == 0 else entry.msgid_plural
     po.save(save_path or po_filepath)
 
 

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -140,7 +140,7 @@ class Translations:
         msgcat = locate_executable("msgcat")
         if msgcat is None:
             msgcat = "/usr/bin/msgcat"
-        cmdline = [msgcat, "--use-first", "-F"]
+        cmdline = [msgcat, "-F"]
         cmdline.extend(from_filenames)
         cmdline.extend(("-o", to_filename))
         reporter.report_debug_info("msgcat cmd line", cmdline)
@@ -183,7 +183,6 @@ class POFile:
             "-o",
             self.FILENAME_PATTERN.format(self.language),
             "--no-translator",
-            "-F",
         ]
         reporter.report_debug_info("msginit cmd line", cmdline)
         portable_popen(cmdline, cwd=self.i18npath).wait()

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -155,7 +155,7 @@ class Translations:
         # Inject the creation date back into the produced file
         with open(to_filename, 'r', encoding='utf-8') as f:
             finishedfile_orig = f.read()
-        replacement = r'\1' + date1 + r'\3'
+        replacement = r'\g<1>' + date1 + r'\g<3>'
         finishedcontent = re.sub(pattern, replacement, finishedfile_orig, count=1)
         with open(to_filename, 'w', encoding='utf-8') as f:
             f.write(finishedcontent)

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -55,6 +55,14 @@ class TemplateTranslator:
         self.init_translator()
         return self.translator.ngettext(*x)
 
+    def pgettext(self, *x):
+        self.init_translator()
+        return self.translator.pgettext(*x)
+
+    def npgettext(self, *x):
+        self.init_translator()
+        return self.translator.npgettext(*x)
+
 
 class Translations:
     """Memory of translations"""

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -5,7 +5,7 @@ import os
 import re
 import tempfile
 import time
-from os.path import exists, join, relpath
+from os.path import exists, join, relpath, basename
 from pprint import PrettyPrinter
 from textwrap import dedent
 from urllib.parse import urljoin
@@ -205,7 +205,7 @@ def fill_translations(po_filepath, save_path=None):
                     entry.msgstr_plural[idx] = entry.msgid if int(idx) == 0 else entry.msgid_plural
                     plural_updated = True
 
-        if plural_updated and 'fuzzy' not in entry.flags:
+        if plural_updated and 'fuzzy' not in entry.flags and 'en' not in basename(po_filepath):
             entry.flags.append('fuzzy')
 
     po.save(save_path or po_filepath)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ authors = [
 maintainers = [
     {name="BeeWare Team", email="team@beeware.org"},
 ]
+dependencies = [
+    "polib",
+]
 
 [project.optional-dependencies]
 # Extras used by developers *of* briefcase are pinned to specific versions to


### PR DESCRIPTION
Exactly what it says on the tin.

Fixes all bugs I can find with this plugin; future updates after this version should be rare.

# Changes

Revision July 22

* Ensure that POT content is now sorted by path when merging POTs from multiple sources (i.e., templates and content).
* `xgettext` is used to merge POT files instead of `msgcat`, providing a better header and merging of same strings from different sources. This is used to ensure that all context will be kept; removing —use-first from msgcat simply causes header trouble.
* The initially generated PO files will now have a header compatible with GNOME's Translation Editor, since they will have a non-placeholder `Project-Id-Version`. This is mostly for my local work — I’ve filled the project id versions manually into the existing POs — but have the good effect of adding a license header (Same license as BeeWare) on top of newly generated POs; I have not went in and added these would’ve-been-generated headers on the existing PO files, though.
* Translations in templates now provide pgettext and npgettext methods. The pgettext is for the sprint helping string (pluralized with speaker count) and the gold member*s* on the front page (pluralization, desperate bug I fixed); pgettext is used to give more context and to work around a bug where trailing spaces get trimmed if regular gettext is used.
* The limitation where deletion of strings from the English PO file with non-English content is required is resolved. See the deletion in the README.
* When updating translated PO files, the content-language PO file strings are automatically filled with the message IDs. Plural forms aren’t filled unless it’s English. [EDIT] This is actually a functional issue; when adding a plural form to a previously singular-only string, msgmerging will actually fill the plural form with the singular form, but fuzzied!! The additional handling ensures that plurals are filled correctly for source-language POs in this case.
* The first bug in https://github.com/beeware/beeware.github.io/issues/689 has been fixed (button on frontpage).

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
